### PR TITLE
Support for zalgo applet.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,5 @@ So far the current tools include:
      * Includes instant preview and the option to copy the output to clipboard.
 * A stutter-ify tool.
      * Changes "l" and "r" to "w" and adds a stutter with about 25% chance.
+* A zalgo (void text) tool.
+     * Transforms the input text to zalgo (void) text.

--- a/Zalgo.html
+++ b/Zalgo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Zalgo Text Generator</title>
+    <style>
+        body { font-family: Arial, sans-serif; text-align: center; margin: 50px; }
+        textarea { width: 80%; height: 100px; }
+        button { margin-top: 10px; padding: 10px; cursor: pointer; }
+    </style>
+</head>
+<body>
+
+    <h2>Zalgo Text Generator</h2>
+    <textarea id="inputText" placeholder="Enter text here..."></textarea><br>
+    <p id="outputText"></p>
+    <button onclick="copyToClipboard()">Copy to Clipboard</button>
+
+    <script>
+    function zalgo(text) {
+        const chars = [ '\u0300', '\u0301', '\u0302', '\u0303', '\u0304', '\u0305', 
+                        '\u0306', '\u0307', '\u0308', '\u0309', '\u030A', '\u030B',
+                        '\u030C', '\u030D', '\u030E', '\u030F', '\u0310', '\u0311',
+                        '\u0312', '\u0313', '\u0314', '\u0315', '\u0316', '\u0317',
+                        '\u0318', '\u0319', '\u031A', '\u031B', '\u031C', '\u031D',
+                        '\u031E', '\u031F', '\u0320', '\u0321', '\u0322', '\u0323',
+                        '\u0324', '\u0325', '\u0326', '\u0327', '\u0328', '\u0329',
+                        '\u032A', '\u032B', '\u032C', '\u032D', '\u032E', '\u032F',
+                        '\u0330', '\u0331', '\u0332', '\u0333', '\u0334', '\u0335',
+                        '\u0336', '\u0337', '\u0338', '\u0339', '\u033A', '\u033B',
+                        '\u033C', '\u033D', '\u033E', '\u033F', '\u0340', '\u0341',
+                        '\u0342', '\u0343', '\u0344', '\u0345', '\u0346', '\u0347',
+                        '\u0348', '\u0349', '\u034A', '\u034B', '\u034C', '\u034D',
+                        '\u034E', '\u034F', '\u0350', '\u0351', '\u0352', '\u0353',
+                        '\u0354', '\u0355', '\u0356', '\u0357', '\u0358', '\u0359',
+                        '\u035A', '\u035B', '\u035C', '\u035D', '\u035E', '\u035F'];
+
+        return text.split('').map(char => char + chars.sort(() => Math.random() - 0.5).slice(0, Math.floor(Math.random() * 8)).join('')).join('');
+    }
+
+    document.getElementById("inputText").addEventListener("input", function() {
+        document.getElementById("outputText").innerText = zalgo(this.value);
+    });
+
+    function copyToClipboard() {
+        let outputText = document.getElementById('outputText').innerText;
+        navigator.clipboard.writeText(outputText).then(() => {
+            alert("Copied to clipboard!");
+        });
+    }
+</script>

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
     <div class="tool-container">
         <div class="tool"><a href="Text-Reverser.html">Text Reverser</a></div>
         <div class="tool"><a href="Stutter-Tool.html">Stutter-ify</a></div>
-        <div class="tool"><a href="tool3.html">Tool 3 (wip)</a></div>
+        <div class="tool"><a href="Zalgo.html">Zalgo Text (wip)</a></div>
     </div>
 
 </body>

--- a/index.html
+++ b/index.html
@@ -48,7 +48,8 @@
     <div class="tool-container">
         <div class="tool"><a href="Text-Reverser.html">Text Reverser</a></div>
         <div class="tool"><a href="Stutter-Tool.html">Stutter-ify</a></div>
-        <div class="tool"><a href="Zalgo.html">Zalgo Text (wip)</a></div>
+        <div class="tool"><a href="Zalgo.html">Zalgo Text</a></div>
+        <div class="tool"><a href="upcoming">(wip)</a>a></div>
     </div>
 
 </body>


### PR DESCRIPTION
I added support for the zalgo applet. Featuring a minimalistic design, this applet will transform the input into zalgo (void) text. 
* Included in this version is:
     * Transformation to zalgo text.
     *  Instant preview and a copy to clipboard button.
     *  Èxa̫mp͔̓l̷̐e